### PR TITLE
Fixing wrong implementation

### DIFF
--- a/EvoCarcassonne/Backend/CardinalDirection.cs
+++ b/EvoCarcassonne/Backend/CardinalDirection.cs
@@ -2,6 +2,6 @@ namespace EvoCarcassonne.Backend
 {
     public enum CardinalDirection
     {
-        NORTH, WEST, EAST, SOUTH
+        North, West, East, South
     }
 }

--- a/EvoCarcassonne/Backend/CardinalDirection.cs
+++ b/EvoCarcassonne/Backend/CardinalDirection.cs
@@ -1,0 +1,7 @@
+namespace EvoCarcassonne.Backend
+{
+    public enum CardinalDirection
+    {
+        NORTH, WEST, EAST, SOUTH
+    }
+}

--- a/EvoCarcassonne/Backend/Direction.cs
+++ b/EvoCarcassonne/Backend/Direction.cs
@@ -2,12 +2,20 @@
 {
     public class Direction : IDirection
     {
-        private int Id { get; set; }
+        public int Id { get; set; }
 
-        private Landscape Landscape { get; set; }
+        public Landscape Landscape { get; set; }
 
-        private Figure Figure { get; set; }
+        public Figure Figure { get; set; }
 
-        private IDirection Neighbor { get; set; }
+        public IDirection Neighbor { get; set; }
+
+        public Direction(int id, Landscape landscape, Figure figure, IDirection neighbor)
+        {
+            Id = id;
+            Landscape = landscape;
+            Figure = figure;
+            Neighbor = neighbor;
+        }
     }
 }

--- a/EvoCarcassonne/Backend/Direction.cs
+++ b/EvoCarcassonne/Backend/Direction.cs
@@ -6,11 +6,11 @@
 
         public Landscape Landscape { get; set; }
 
-        public Figure Figure { get; set; }
+        public IFigure Figure { get; set; }
 
         public IDirection Neighbor { get; set; }
 
-        public Direction(int id, Landscape landscape, Figure figure, IDirection neighbor)
+        public Direction(int id, Landscape landscape, IFigure figure, IDirection neighbor)
         {
             Id = id;
             Landscape = landscape;

--- a/EvoCarcassonne/Backend/Figure.cs
+++ b/EvoCarcassonne/Backend/Figure.cs
@@ -3,9 +3,9 @@
     public class Figure : IFigure
     {
         public int Id { get; set; }
-        public Owner Owner { get; set; }
+        public IOwner Owner { get; set; }
 
-        public Figure(int id, Owner owner)
+        public Figure(int id, IOwner owner)
         {
             Id = id;
             Owner = owner;

--- a/EvoCarcassonne/Backend/Figure.cs
+++ b/EvoCarcassonne/Backend/Figure.cs
@@ -1,8 +1,14 @@
 ﻿namespace EvoCarcassonne.Backend
 {
-    public class Figure
+    public class Figure : IFigure
     {
-        private Owner Owner { get; set; }
-        private int ID { get; set; }     
+        public int Id { get; set; }
+        public Owner Owner { get; set; }
+
+        public Figure(int id, Owner owner)
+        {
+            Id = id;
+            Owner = owner;
+        }
     }
 }

--- a/EvoCarcassonne/Backend/IDirection.cs
+++ b/EvoCarcassonne/Backend/IDirection.cs
@@ -6,7 +6,7 @@
 
         Landscape Landscape { get; set; }
 
-        Figure Figure { get; set; }
+        IFigure Figure { get; set; }
 
         IDirection Neighbor { get; set; }
     }

--- a/EvoCarcassonne/Backend/IDirection.cs
+++ b/EvoCarcassonne/Backend/IDirection.cs
@@ -2,5 +2,12 @@
 {
     public interface IDirection
     {
+        int Id { get; set; }
+
+        Landscape Landscape { get; set; }
+
+        Figure Figure { get; set; }
+
+        IDirection Neighbor { get; set; }
     }
 }

--- a/EvoCarcassonne/Backend/IFigure.cs
+++ b/EvoCarcassonne/Backend/IFigure.cs
@@ -1,0 +1,8 @@
+namespace EvoCarcassonne.Backend
+{
+    public interface IFigure
+    {
+        Owner Owner { get; set; }
+        int Id { get; set; }
+    }
+}

--- a/EvoCarcassonne/Backend/IFigure.cs
+++ b/EvoCarcassonne/Backend/IFigure.cs
@@ -2,7 +2,7 @@ namespace EvoCarcassonne.Backend
 {
     public interface IFigure
     {
-        Owner Owner { get; set; }
+        IOwner Owner { get; set; }
         int Id { get; set; }
     }
 }

--- a/EvoCarcassonne/Backend/IOwner.cs
+++ b/EvoCarcassonne/Backend/IOwner.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace EvoCarcassonne.Backend
+{
+    public interface IOwner
+    {
+        int Id { get; set; }
+        String Name { get; set; }
+    }
+}

--- a/EvoCarcassonne/Backend/ITile.cs
+++ b/EvoCarcassonne/Backend/ITile.cs
@@ -1,7 +1,14 @@
-﻿namespace EvoCarcassonne.Backend
+﻿using System.Collections.Generic;
+
+namespace EvoCarcassonne.Backend
 {
     public interface ITile
+
     {
-        void Rotate(IDirection direction);
+        int TileID { get; set; }
+        List<IDirection> Directions { get; set; }
+        Speciality Speciality { get; set; }
+        void Rotate(int direction);
+        IDirection getTileSideByCardinalDirection(CardinalDirection side);
     }
 }

--- a/EvoCarcassonne/Backend/Owner.cs
+++ b/EvoCarcassonne/Backend/Owner.cs
@@ -1,6 +1,15 @@
 ﻿namespace EvoCarcassonne.Backend
 {
-    public class Owner
+    public class Owner : IOwner
     {
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+
+        public Owner(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
     }
 }

--- a/EvoCarcassonne/Backend/Owner.cs
+++ b/EvoCarcassonne/Backend/Owner.cs
@@ -1,12 +1,14 @@
-﻿namespace EvoCarcassonne.Backend
+﻿using System;
+
+namespace EvoCarcassonne.Backend
 {
     public class Owner : IOwner
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public String Name { get; set; }
 
 
-        public Owner(int id, string name)
+        public Owner(int id, String name)
         {
             Id = id;
             Name = name;

--- a/EvoCarcassonne/Backend/Tile.cs
+++ b/EvoCarcassonne/Backend/Tile.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Windows.Data;
 
@@ -46,7 +47,7 @@ namespace EvoCarcassonne.Backend
                     Directions[0] = temp;
                     break;
                 default:
-                    Console.WriteLine(@"[ERROR] You have given a wrong rotation value!");
+                    Debug.WriteLine(@"[ERROR] You have given a wrong rotation value!");
                     break;
             }
         }

--- a/EvoCarcassonne/Backend/Tile.cs
+++ b/EvoCarcassonne/Backend/Tile.cs
@@ -1,26 +1,68 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Data;
 
 namespace EvoCarcassonne.Backend
 {
     public class Tile : ITile
     {
-        private List<IDirection> Directions { get; set; }
-        private Speciality Speciality { get; set; }
+        public int TileID { get; set; }
+        public List<IDirection> Directions { get; set; }
+        public Speciality Speciality { get; set; }
 
-        public void Rotate(IDirection direction)
+
+        public Tile(int tileId, List<IDirection> directions, Speciality speciality)
         {
-            return;
+            TileID = tileId;
+            Directions = directions;
+            Speciality = speciality;
         }
 
-        public IDirection GetPropertyByIndex(int index)
+        /**
+         * Rotate the tile depending on the given parameter.
+         */
+        public void Rotate(int direction)
         {
-            if (index > 3)
+            IDirection temp;
+            switch (direction)
             {
-                return null;
+                case -90:
+                    temp = Directions.First();
+                    for (int i = 0; i < Directions.Count - 1; i++)
+                    {
+                        Directions[i] = Directions[i+1];
+                    }
+
+                    Directions[Directions.Count] = temp;
+                    break;
+                case 90:
+                    temp = Directions.Last();
+                    for (int i = 0; i < Directions.Count - 1; i++)
+                    {
+                        Directions[i+1] = Directions[i];
+                    }
+
+                    Directions[0] = temp;
+                    break;
+                default:
+                    Console.WriteLine(@"[ERROR] You have given a wrong rotation value!");
+                    break;
             }
-            else
+        }
+
+        /**
+         * Returns the queried side of the tile. If wrong side is given, it returns with the North side of the tile.
+         */
+        public IDirection getTileSideByCardinalDirection(CardinalDirection side)
+        {
+            switch (side)
             {
-                return this.Directions[index];
+                case CardinalDirection.NORTH: return Directions[0];
+                case CardinalDirection.EAST: return Directions[1];
+                case CardinalDirection.SOUTH: return Directions[2];
+                case CardinalDirection.WEST: return Directions[3];
+                default: return Directions[0];
             }
         }
     }

--- a/EvoCarcassonne/EvoCarcassonne.csproj
+++ b/EvoCarcassonne/EvoCarcassonne.csproj
@@ -63,9 +63,12 @@
       <DependentUpon>App.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Backend\CardinalDirection.cs" />
     <Compile Include="Backend\Direction.cs" />
     <Compile Include="Backend\Figure.cs" />
     <Compile Include="Backend\IDirection.cs" />
+    <Compile Include="Backend\IFigure.cs" />
+    <Compile Include="Backend\IOwner.cs" />
     <Compile Include="Backend\ITile.cs" />
     <Compile Include="Backend\Owner.cs" />
     <Compile Include="Backend\Speciality.cs" />


### PR DESCRIPTION
Fixed implementations:
- CardinalDirection enum hozzáadva hogy egy kártya oldalait reprezentálja
- private poropertik mostmár public-ok
- constructorokat használ minden osztály
- getPropertyByIndex új neve: getTileSideByCardinalDirection
- Rotate implementálva
- Minden osztály kapott ID-t
- Owner osztály létrehozva
- Interfészek tartalmazzák a propertyket

Ezeket változtattam. Légyszi nézzétek meg hogy van-e benne hiba. Köszi. 😄 